### PR TITLE
chore: re-add main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
       "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
TypeScript only supports `exports` in `--moduleResolution node16` or `nodenext`.
See <https://github.com/microsoft/TypeScript/issues/49971#issuecomment-1192993398>